### PR TITLE
Handle empty livery file

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -231,6 +231,14 @@ namespace TSW2_Livery_Manager
                 byte[] LiveryFile = File.ReadAllBytes(Cfg["GamePath"]);
 
                 int HeaderEnd = LocateInByteArray(LiveryFile, SOL);
+                if (HeaderEnd < 0)
+
+                {
+                    Log.AddLogMessage("No livery found - at least one livery needs to already exist.", "MW::LoadGameLiveries",  Log.LogLevel.ERROR);
+                    ((Data)DataContext).Useable = false;
+                    return "Empty livery file - please ensure you've created at least one livery.";
+                }
+
                 byte[] Header = new byte[HeaderEnd];
                 Array.Copy(LiveryFile, Header, Header.Length);
                 SplitFile.Add(0, Header);


### PR DESCRIPTION
fix #3

The obvious ideal solution would be handle a empty file like any other. Unfortunately, as far as I can tell, the "Header" part of the livery file does change between an empty and non-empty file and changing the header in such a way seems fairly difficult. 

Instead this PR simply displays an error message if no livery is found instead of crashing. 