### PR TITLE
Improved model string

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -337,7 +337,7 @@ namespace TSW2_Livery_Manager
 
             if (Name == null || Model == null) return null;
 
-            return $"{Name} for {Model}";
+            return $"{Model} | {Name}";
         }
 
         private string getLiveryName(byte[] liveryData)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -337,6 +337,11 @@ namespace TSW2_Livery_Manager
 
             if (Name == null || Model == null) return null;
 
+            if (Model.StartsWith("RF_"))
+            {
+                Model = Model.Remove(0, 3);
+            }
+
             return $"{Model} | {Name}";
         }
 


### PR DESCRIPTION
Wanted to improve a bit the list of liveries to make it more user-friendly. I thought that displaying the stock model first and then the livery name could be better (see below).

I've also removed the "RF_" prefix that every model seems to have.

Should not affect the save/load/etc. behavior.

Before:
![image](https://user-images.githubusercontent.com/7879584/103764882-92f88900-501c-11eb-9403-4165db6db212.png)

After:
![image](https://user-images.githubusercontent.com/7879584/103764897-9be95a80-501c-11eb-8fe8-d5d011116f6f.png)
