### PR TITLE
Library liveries are now sorted by livery name and not by file name.

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -394,6 +394,11 @@ namespace TSW2_Livery_Manager
                 lstLibraryLiveries.Items.Add($"{Display} <{file.Name}>");
                 Log.AddLogMessage($"Added library livery {file.Name} ({Display})", "MW::UpdateLocalGameLiveries", Log.LogLevel.DEBUG);
             }
+            if (lstLibraryLiveries.Items.CanSort)
+            {
+                lstLibraryLiveries.Items.SortDescriptions.Add(
+                    new SortDescription("", ListSortDirection.Ascending));
+            }
             return "OK";
         }
 


### PR DESCRIPTION
A small improvement that sorts the list of liveries by name and not by filename, as the filename gets often changed.